### PR TITLE
34 resolve build and push multiarch image

### DIFF
--- a/NotesToSelf.md
+++ b/NotesToSelf.md
@@ -2,8 +2,32 @@
 
 ## Releasing a new version
 
+Note that we build using `buildx` as we are building a multi-platform docker image.
+
+```sh
+yarn version <major|minor|patch>
+docker buildx build --platform=linux/amd64,linux/arm64 -t skarpdev/aws-secrets-manager-emulator:<version> --push .
 ```
-npm version <major|minor|patch>
-docker build -t skarpdev/aws-secrets-manager-emulator:<version> .
-docker push skarpdev/aws-secrets-manager-emulator:<version>
+
+Version should be something like `1.2.3`.
+
+### No buildx
+
+Ensure that your version of docker is at least `19.03` (as that is where `buildx` was added).
+
+
+### If it fails building for one of the platforms
+
+If the build fails building for one of the platforms, then the QEMU stuff probably has to be updated.
+
+```sh
+docker run --privileged --rm tonistiigi/binfmt --install all
+sudo apt-get install qemu qemu-user-static
+docker run --rm -t arm64v8/ubuntu uname -m  # Testing the emulation environment
+```
+
+If the QEMU stuff stops working, then try:
+
+```sh
+docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-secretsmanager-emulator",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Emulator for AWS Secrets Manager",
   "main": "main/index.js",
   "author": "Patrick Boisen <patrick@skarp.dk>",


### PR DESCRIPTION
Fixes #34 

This does not change any code, but it changes the notes on how we release this software. Specifically it changes the docker commands we use - we now use `buildx` so we can build multi-platform images.

We now build images for `linux/amd64` and `linux/arm64`. The latter _should_ work for `Apple M1`.